### PR TITLE
CI github-actions-cache-cleaner: permissions修正

### DIFF
--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
-permissions: read-all
+permissions:
+  actions: write
 jobs:
   github-actions-cache-cleaner:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/massongit/analog-clock-next-react/actions/runs/13359794927/job/37307621343

```
RequestError [HttpError]: Resource not accessible by integration
```

上記を修正するため、`actions: write` を付与します。